### PR TITLE
Fix the cursor position resetting to 0 when there's a space on either side of the address field

### DIFF
--- a/app/src/main/java/cash/z/ecc/android/ui/send/SendAddressFragment.kt
+++ b/app/src/main/java/cash/z/ecc/android/ui/send/SendAddressFragment.kt
@@ -69,10 +69,13 @@ class SendAddressFragment : BaseFragment<FragmentSendAddressBinding>(),
 
         binding.inputZcashAddress.apply {
             doAfterTextChanged {
-                val trim = text.toString().trim()
+                val textStr = text.toString()
+                val trim = textStr.trim()
                 if (text.toString() != trim) {
-                    binding.inputZcashAddress
-                        .findViewById<EditText>(R.id.input_zcash_address).setText(trim)
+                    val textView = binding.inputZcashAddress.findViewById<EditText>(R.id.input_zcash_address)
+                    val cursorPosition = textView.selectionEnd;
+                    textView.setText(trim)
+                    textView.setSelection(cursorPosition-(textStr.length-trim.length))
                 }
                 onAddressChanged(trim)
             }


### PR DESCRIPTION
Fixes #169

Every time the address TextField is changed it is automatically trimmed, however the setText method resets the cursor position which caused issue #169. The reason this happened after 6, 6, and 2 backspaces is because those were the positions of spaces between words of the pasted text. Additionally a similar problem would occur if the user had simply tried to enter a space.

This is fixed by storing the cursor position before applying the trim, and then simply restoring it while subtracting the difference in length between the original and the trimmed strings to account for the removed characters and prevent out of bounds.