### PR TITLE
Bugfix: Up arrow behavior on send screen

### DIFF
--- a/app/src/main/java/cash/z/ecc/android/ui/send/SendAddressFragment.kt
+++ b/app/src/main/java/cash/z/ecc/android/ui/send/SendAddressFragment.kt
@@ -36,7 +36,7 @@ class SendAddressFragment : BaseFragment<FragmentSendAddressBinding>(),
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        binding.backButtonHitArea.onClickNavTo(R.id.action_nav_send_address_to_nav_home) { tapped(SEND_ADDRESS_BACK) }
+        binding.backButtonHitArea.onClickNavUp { tapped(SEND_ADDRESS_BACK) }
         binding.buttonNext.setOnClickListener {
             onSubmit().also { tapped(SEND_ADDRESS_NEXT) }
         }


### PR DESCRIPTION
Fixes #106 per suggestions from @CrystalPony.

The send screen can be reached in two primary ways, from pressing the send button and from scanning. Previously, the scan fragment was staying on the stack and code was written to always go back to the homescreen when exiting the send flow. Since then, the `mobile_navigation.xml` has been fixed and the scan screen correctly excludes itself from the stack.

So the fix here was to simply navigate up.

Credit to @CrystalPony for correctly diagnosing the problem. As far as I'm concerned, CrystalPony fixed this bug!