### PR TITLE
Fix: security finding in issue #121.

### DIFF
--- a/app/src/main/java/cash/z/ecc/android/ui/profile/ProfileFragment.kt
+++ b/app/src/main/java/cash/z/ecc/android/ui/profile/ProfileFragment.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.launch
 import okio.Okio
 import java.io.File
 import java.io.IOException
+import java.lang.IllegalArgumentException
 
 
 class ProfileFragment : BaseFragment<FragmentProfileBinding>() {
@@ -110,7 +111,12 @@ class ProfileFragment : BaseFragment<FragmentProfileBinding>() {
     private fun writeLogcat(): File? {
         try {
             val outputFile = File("${ZcashWalletApp.instance.filesDir}/logs", "developer_log.txt")
-            val cmd = arrayOf("/bin/sh", "-c", "logcat -v time -d | grep \"@TWIG\" > ${outputFile.absolutePath}")
+            if (!outputFile.parentFile.isFile) {
+                // addresses security finding in issue #121
+                throw IllegalArgumentException("Invalid path: ${outputFile.absolutePath}. Verify" +
+                        " that the default files directory is not being manipulated.")
+            }
+            val cmd = arrayOf("/bin/sh", "-c", "logcat -v time -d | grep \"@TWIG\" > \"${outputFile.absolutePath}\"")
             Runtime.getRuntime().exec(cmd)
             return outputFile
         } catch (e: IOException) {

--- a/app/src/main/java/cash/z/ecc/android/ui/profile/ProfileFragment.kt
+++ b/app/src/main/java/cash/z/ecc/android/ui/profile/ProfileFragment.kt
@@ -110,13 +110,14 @@ class ProfileFragment : BaseFragment<FragmentProfileBinding>() {
 
     private fun writeLogcat(): File? {
         try {
-            val outputFile = File("${ZcashWalletApp.instance.filesDir}/logs", "developer_log.txt")
-            if (!outputFile.parentFile.isFile) {
+            // Note: the /logs directory has been configured as a file provider under @xml/file_paths which allows the temporary sharing of this file
+            val outputFile = File("${ZcashWalletApp.instance.filesDir}/logs", "developer_log.txt").also { it.parentFile.mkdirs() }
+            if (!outputFile.parentFile.isDirectory) {
                 // addresses security finding in issue #121
-                throw IllegalArgumentException("Invalid path: ${outputFile.absolutePath}. Verify" +
+                throw IllegalArgumentException("Invalid path: ${outputFile.parentFile}. Verify" +
                         " that the default files directory is not being manipulated.")
             }
-            val cmd = arrayOf("/bin/sh", "-c", "logcat -v time -d | grep \"@TWIG\" > \"${outputFile.absolutePath}\"")
+            val cmd = arrayOf("/bin/sh", "-c", "logcat -v time -d | grep '@TWIG' > '${outputFile.absolutePath}'")
             Runtime.getRuntime().exec(cmd)
             return outputFile
         } catch (e: IOException) {


### PR DESCRIPTION
Avoids shell injection by verifying that the supplied value is a file. Also allows for spaces in the file path, which probably fixes certain devices that were crashing when trying to open logs.