### PR TITLE
Fix: remove the deprecated kotlin extensions plugin.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,6 @@ import cash.z.ecc.android.Deps
 
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 apply plugin: "androidx.navigation.safeargs.kotlin"
 apply plugin: 'com.github.ben-manes.versions'

--- a/feedback/build.gradle
+++ b/feedback/build.gradle
@@ -2,7 +2,6 @@ import cash.z.ecc.android.Deps
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion Deps.compileSdkVersion

--- a/lockbox/build.gradle
+++ b/lockbox/build.gradle
@@ -2,7 +2,6 @@ import cash.z.ecc.android.Deps
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 
 repositories {
     google()


### PR DESCRIPTION
This was included in the template project created by android studio and was never used in a significant way. It has been deprecated by google and is safe to remove from the build files.