### PR TITLE
Enable strict mode in the app for debug builds

### DIFF
--- a/app/src/main/java/cash/z/ecc/android/StrictModeHelper.kt
+++ b/app/src/main/java/cash/z/ecc/android/StrictModeHelper.kt
@@ -1,0 +1,60 @@
+package cash.z.ecc.android
+
+import android.annotation.SuppressLint
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import android.os.StrictMode
+
+object StrictModeHelper {
+
+    fun enableStrictMode() {
+        configureStrictMode()
+
+        // Workaround for Android bug
+        // https://issuetracker.google.com/issues/36951662
+        // Not needed if target O_MR1 and running on O_MR1
+        // Don't really need to check target, because of Google Play enforcement on targetSdkVersion for app updates
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O_MR1) {
+            Handler(Looper.getMainLooper()).postAtFrontOfQueue { configureStrictMode() }
+        }
+    }
+
+    @SuppressLint("NewApi")
+    private fun configureStrictMode() {
+        StrictMode.enableDefaults()
+
+        StrictMode.setThreadPolicy(
+            StrictMode.ThreadPolicy.Builder().apply {
+                detectAll()
+                penaltyLog()
+            }.build()
+        )
+
+        // Don't enable missing network tags, because those are noisy.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            StrictMode.setVmPolicy(
+                StrictMode.VmPolicy.Builder().apply {
+                    detectActivityLeaks()
+                    detectCleartextNetwork()
+                    detectContentUriWithoutPermission()
+                    detectFileUriExposure()
+                    detectLeakedClosableObjects()
+                    detectLeakedRegistrationObjects()
+                    detectLeakedSqlLiteObjects()
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                        // Disable because this is mostly flagging Android X and Play Services
+                        // builder.detectNonSdkApiUsage();
+                    }
+                }.build()
+            )
+        } else {
+            StrictMode.setVmPolicy(
+                StrictMode.VmPolicy.Builder().apply {
+                    detectAll()
+                    penaltyLog()
+                }.build()
+            )
+        }
+    }
+}

--- a/app/src/main/java/cash/z/ecc/android/ZcashWalletApp.kt
+++ b/app/src/main/java/cash/z/ecc/android/ZcashWalletApp.kt
@@ -2,7 +2,6 @@ package cash.z.ecc.android
 
 import android.app.Application
 import android.content.Context
-import android.os.Build
 import androidx.camera.camera2.Camera2Config
 import androidx.camera.core.CameraXConfig
 import cash.z.ecc.android.di.component.AppComponent
@@ -43,12 +42,32 @@ class ZcashWalletApp : Application(), CameraXConfig.Provider {
      */
     private var feedbackScope: CoroutineScope = CoroutineScope(Dispatchers.Main + SupervisorJob())
 
-    override fun onCreate() {
-        Thread.setDefaultUncaughtExceptionHandler(ExceptionReporter(Thread.getDefaultUncaughtExceptionHandler()))
-        creationTime = System.currentTimeMillis()
+    override fun attachBaseContext(base: Context?) {
+        super.attachBaseContext(base)
+
+        // Setting a global reference to the application object is icky; we should try to refactor
+        // this away if possible.  Doing this in attachBaseContext instead of onCreate()
+        // to avoid any lifecycle issues, as certain components can run before Application.onCreate()
+        // (like ContentProvider initialization), but attachBaseContext will still run before that.
         instance = this
-        // Setup handler for uncaught exceptions.
+    }
+
+    override fun onCreate() {
         super.onCreate()
+
+        // Register this before the uncaught exception handler, because we want to make sure the
+        // exception handler also doesn't do disk IO.  Since StrictMode only applies for debug builds,
+        // we'll also see the crashes during development right away and won't miss them if they aren't
+        // reported by the crash reporting.
+        if (BuildConfig.DEBUG) {
+            StrictModeHelper.enableStrictMode()
+        }
+
+        // Setup handler for uncaught exceptions.
+        Thread.getDefaultUncaughtExceptionHandler()?.let {
+            Thread.setDefaultUncaughtExceptionHandler(ExceptionReporter(it))
+        }
+        creationTime = System.currentTimeMillis()
 
         defaultNetwork = ZcashNetwork.from(resources.getInteger(R.integer.zcash_network_id))
         component = DaggerAppComponent.factory().create(this)
@@ -56,11 +75,6 @@ class ZcashWalletApp : Application(), CameraXConfig.Provider {
         feedbackScope.launch {
             coordinator.feedback.start()
         }
-    }
-
-    override fun attachBaseContext(base: Context) {
-        super.attachBaseContext(base)
-//        MultiDex.install(this)
     }
 
     override fun getCameraXConfig(): CameraXConfig {
@@ -107,11 +121,4 @@ class ZcashWalletApp : Application(), CameraXConfig.Provider {
             }
         }
     }
-}
-
-fun ZcashWalletApp.isEmulator(): Boolean {
-    val goldfish = Build.HARDWARE.contains("goldfish")
-    val emu = (System.getProperty("ro.kernel.qemu", "")?.length ?: 0) > 0
-    val sdk = Build.MODEL.toLowerCase().contains("sdk")
-    return goldfish || emu || sdk
 }

--- a/lockbox/build.gradle
+++ b/lockbox/build.gradle
@@ -3,11 +3,6 @@ import cash.z.ecc.android.Deps
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
-repositories {
-    google()
-    mavenCentral()
-}
-
 android {
     compileSdkVersion Deps.compileSdkVersion
     buildToolsVersion Deps.buildToolsVersion


### PR DESCRIPTION
This change is part of my work to implement #269.  Since 269 requires using a persisted preference, I want to avoid introducing additional disk IO on the main thread.  This PR will help by providing additional debugging information during development of the app, while disabling the information for release builds.

This additional debug information may be a bit noisy until we resolve a variety of root causes, many of which are coming from the SDK.  See https://github.com/zcash/zcash-android-wallet-sdk/issues/269 which is tracking this.

To test this change, run a debug build of the app and look at logcat. Logs like the following should appear

```
2021-09-02 09:47:28.077 10109-10109/cash.z.ecc.android D/StrictMode: StrictMode policy violation; ~duration=81 ms: android.os.strictmode.DiskReadViolation
        at android.os.StrictMode$AndroidBlockGuardPolicy.onReadFromDisk(StrictMode.java:1596)
        at android.database.sqlite.SQLiteConnection.applyBlockGuardPolicy(SQLiteConnection.java:1197)
        at android.database.sqlite.SQLiteConnection.executeForLong(SQLiteConnection.java:747)
        at android.database.sqlite.SQLiteConnection.setJournalSizeLimit(SQLiteConnection.java:311)
        at android.database.sqlite.SQLiteConnection.open(SQLiteConnection.java:259)
        at android.database.sqlite.SQLiteConnection.open(SQLiteConnection.java:205)
        at android.database.sqlite.SQLiteConnectionPool.openConnectionLocked(SQLiteConnectionPool.java:505)
        at android.database.sqlite.SQLiteConnectionPool.open(SQLiteConnectionPool.java:206)
        at android.database.sqlite.SQLiteConnectionPool.open(SQLiteConnectionPool.java:198)
        at android.database.sqlite.SQLiteDatabase.openInner(SQLiteDatabase.java:918)
        at android.database.sqlite.SQLiteDatabase.open(SQLiteDatabase.java:898)
        at android.database.sqlite.SQLiteDatabase.openDatabase(SQLiteDatabase.java:762)
        at android.database.sqlite.SQLiteDatabase.openDatabase(SQLiteDatabase.java:751)
        at android.database.sqlite.SQLiteOpenHelper.getDatabaseLocked(SQLiteOpenHelper.java:373)
        at android.database.sqlite.SQLiteOpenHelper.getWritableDatabase(SQLiteOpenHelper.java:316)
        at androidx.sqlite.db.framework.FrameworkSQLiteOpenHelper$OpenHelper.getWritableSupportDatabase(FrameworkSQLiteOpenHelper.java:145)
        at androidx.sqlite.db.framework.FrameworkSQLiteOpenHelper.getWritableDatabase(FrameworkSQLiteOpenHelper.java:106)
        at cash.z.ecc.android.sdk.transaction.PagedTransactionRepository.buildDatabase(PagedTransactionRepository.kt:179)
        at cash.z.ecc.android.sdk.transaction.PagedTransactionRepository.prepare(PagedTransactionRepository.kt:105)
        at cash.z.ecc.android.sdk.SdkSynchronizer.prepare(SdkSynchronizer.kt:251)
        at cash.z.ecc.android.sdk.SdkSynchronizer$onReady$2.invokeSuspend(SdkSynchronizer.kt:394)
        at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
        at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
        at android.os.Handler.handleCallback(Handler.java:938)
        at android.os.Handler.dispatchMessage(Handler.java:99)
        at android.os.Looper.loop(Looper.java:223)
        at android.app.ActivityThread.main(ActivityThread.java:7656)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:592)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:947)
```